### PR TITLE
See Individual Reminder (Closes #4)

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -8,7 +8,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('reminders', function() {
-    this.route('reminder');
+    this.route('reminder', {path: ':reminder_id'});
   });
 });
 

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
-
 export default Ember.Route.extend({
+	model: function(params) {
+		return this.get('store').find('reminder', params.reminder_id);
+	}
 });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,1 +1,3 @@
-
+.active {
+  background-color: papayawhip;
+}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,9 +1,10 @@
 	<ul>
 	{{#each model as |reminder|}}
 	<li class="spec-reminder-item">
-		<h3>{{reminder.title}}</h3>
-		<p>{{reminder.notes}}</p>
+		<h3>{{#link-to 'reminders.reminder' reminder.id}} {{reminder.title}} {{/link-to}}</h3>
 		<p>{{reminder.date}}</p>
 	</li>
 	{{/each}}
 </ul>
+
+{{outlet}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,7 +1,7 @@
 	<ul>
 	{{#each model as |reminder|}}
-	<li class="spec-reminder-item">
-		<h3>{{#link-to 'reminders.reminder' reminder.id}} {{reminder.title}} {{/link-to}}</h3>
+	<li>
+		<h3>{{#link-to 'reminders.reminder' reminder.id class="spec-reminder-item"}} {{reminder.title}} {{/link-to}}</h3>
 		<p>{{reminder.date}}</p>
 	</li>
 	{{/each}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,1 +1,7 @@
+<article class="spec-individual-reminder-item">
+  <h2>{{reminder.title}}</h2>
+  <div>{{reminder.date}}</div>
+  <p>{{reminder.notes}}</p>
+</article>
+
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,7 +1,5 @@
 <article class="spec-individual-reminder-item">
-  <h2>{{reminder.title}}</h2>
-  <div>{{reminder.date}}</div>
-  <p>{{reminder.notes}}</p>
+  <h2>{{model.title}}</h2>
+  <div>{{model.date}}</div>
+  <p>{{model.notes}}</p>
 </article>
-
-{{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,5 +1,5 @@
-<article class="spec-individual-reminder-item">
-  <h2>{{model.title}}</h2>
+<article class="active">
+  <h2 class="spec-reminder-title">{{model.title}}</h2>
   <div>{{model.date}}</div>
   <p>{{model.notes}}</p>
 </article>

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -25,7 +25,7 @@ test('clicking on an individual item', function(assert) {
   click('.spec-reminder-item:first');
 
   andThen(function() {
-    assert.equal(currentURL(), '/1');
+    assert.equal(currentURL(), '/reminders/1');
     assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), Ember.$('.spec-reminder-title').text().trim());
   });
 });


### PR DESCRIPTION
## Purpose

This PR adds functionality for rendering the notes for an individual reminder below the list of reminders when clicking on the title on an individual reminder in the list of reminders (wheew.......). The notes for that individual reminder will be rendered below and highlighted in papayawhip (one of CSS's finest hues).

## Approach

We generated a new route to 'reminders/:reminder_id" (nested within "/reminders"), and built out a new template for a reminder, which renders the reminder's notes and title within the outlet of the reminders template. 

### Learning

We followed the EmberJS guide for templates and routes. 

#### Blog Posts

### Open Questions and Pre-Merge TODOs

- [x ] Routes to '/reminders/{reminder.id}' when clicking a reminder's title
- [x] Renders the reminder's notes on the page beneath the reminders list
- [x] Title click test passes (27/27 tests passing)

### Test coverage 

We test the on-click functionality of the reminder title with the 'clicking on an individual reminder renderes that reminder's notes and title below the reminder list' test
### Merge Dependencies and Related Work


Closes #3
### Follow-up tasks
