### PR TITLE
Display default page #8

### DIFF
--- a/app/templates/components/new-reminder.hbs
+++ b/app/templates/components/new-reminder.hbs
@@ -1,5 +1,3 @@
-<h2>New Reminder</h2>
-
 <form class="add--reminder" {{action 'createReminder' on="submit"}}>
   <label>
     Title

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,6 +1,7 @@
 <div>
 	<h2>Reminders</h2>
 
+{{#if reminder}}
 	<ul>
 	{{#each model as |reminder|}}
 	<li class='reminder'>
@@ -10,11 +11,13 @@
 	{{/each}}
 </ul>
 
+{{else}}
+<p>Please add a reminder</p>
 
-
+{{/if}}
 
 <button >
-{{#link-to 'reminders.new' class="add-btn"}}Add New Reminder{{/link-to}}</button>
+{{#link-to 'reminders.new' class="add-btn"}}Add{{/link-to}}</button>
 </div>
 
 

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,28 +1,27 @@
 <div>
 	<h2>remEMBER</h2>
 
-{{#if model}}
-	<ul class="reminder-list">
-		{{#each model as |reminder|}}
-			<li class='reminder'>
-				<h3>
-					{{#link-to 'reminders.reminder' reminder.id class="spec-reminder-item"}}
-					{{reminder.title}}
-					{{/link-to}}
-				</h3>
-				<p>{{reminder.date}}</p>
-			</li>
-		{{/each}}
-</ul>
+	{{#if model}}
+		<ul class="reminder-list">
+			{{#each model as |reminder|}}
+				<li class='reminder'>
+					<h3>
+						{{#link-to 'reminders.reminder' reminder.id class="spec-reminder-item"}}
+						{{reminder.title}}
+						{{/link-to}}
+					</h3>
+					<p>{{reminder.date}}</p>
+				</li>
+			{{/each}}
+	</ul>
 
-{{else}}
-<p class="welcome-default">Welcome! Click 'add' to create a new reminder.</p>
+	{{else}}
+		<p class="welcome-default">Welcome! Click 'add' to create a new reminder.</p>
+	{{/if}}
 
-{{/if}}
-
-<button >
-	{{#link-to 'reminders.new' class="add-btn"}}Add{{/link-to}}
-</button>
+	<button >
+		{{#link-to 'reminders.new' class="add-btn"}}Add{{/link-to}}
+	</button>
 </div>
 
 

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,23 +1,28 @@
 <div>
-	<h2>Reminders</h2>
+	<h2>remEMBER</h2>
 
-{{#if reminder}}
-	<ul>
-	{{#each model as |reminder|}}
-	<li class='reminder'>
-		<h3>{{#link-to 'reminders.reminder' reminder.id class="spec-reminder-item"}} {{reminder.title}} {{/link-to}}</h3>
-		<p>{{reminder.date}}</p>
-	</li>
-	{{/each}}
+{{#if model}}
+	<ul class="reminder-list">
+		{{#each model as |reminder|}}
+			<li class='reminder'>
+				<h3>
+					{{#link-to 'reminders.reminder' reminder.id class="spec-reminder-item"}}
+					{{reminder.title}}
+					{{/link-to}}
+				</h3>
+				<p>{{reminder.date}}</p>
+			</li>
+		{{/each}}
 </ul>
 
 {{else}}
-<p>Please add a reminder</p>
+<p class="welcome-default">Welcome! Click 'add' to create a new reminder.</p>
 
 {{/if}}
 
 <button >
-{{#link-to 'reminders.new' class="add-btn"}}Add{{/link-to}}</button>
+	{{#link-to 'reminders.new' class="add-btn"}}Add{{/link-to}}
+</button>
 </div>
 
 

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,3 +1,0 @@
-export default function() {
-  // server.createList('reminder', 5);
-}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -63,3 +63,13 @@ test("should add a reminder on submit with valid input", function(assert) {
 		assert.equal(Ember.$('.spec-reminder-item').text().trim(), 'hello');
 	});
 });
+
+test('viewing the homepage will reroute to /reminders and display a welcome page when there are zero reminders', function(assert) {
+	visit('/');
+
+	andThen(function() {
+		assert.equal(currentURL(), '/reminders');
+		assert.equal(Ember.$('.spec-reminder-item').length, 0);
+		assert.equal(find('.welcome-default').length, 1);
+	});
+});


### PR DESCRIPTION
## Purpose
@martensonbj @Tman22 @stevekinney @nfosterky @nnchambs 

Update reminder component to have a conditional that will only display notes if notes exist.

There should be a default welcome page welcoming users to the app and/or directions to create a new note. Feel free to be creative here.

## Approach

We added a conditional statement in the reminders.hbs file to check the model and see if a reminder exists. If there are zero reminders, the welcome page will be displayed along with the add button. If there are reminders, those will be rendered.

### Learning

https://guides.emberjs.com/v2.2.0/templates/conditionals/

#### Blog Posts

### Open Questions and Pre-Merge TODOs

- [x] Create a conditional that will only display reminders if reminders exist.
- [x] With the conditional, display a default welcome page if there are no reminders.
- [x] Create tests for these added functionality. 

### Test coverage 

We created tests to ensure the user is still redirected to '/reminders', and that when there is a condition of zero reminders, the default page renders.

### Merge Dependencies and Related Work

This closes #8.
