### PR TITLE
Visual cue for unsaved reminder

### DIFF
--- a/app/components/reminder-form.js
+++ b/app/components/reminder-form.js
@@ -6,9 +6,9 @@ export default Ember.Component.extend({
 
   actions: {
     handleFormSubmit(model) {
-    model.date = model.date || new Date();
-		model.save();
-		this.sendAction();
+	    model.date = model.date || new Date();
+			model.save();
+			this.sendAction();
 	},
 	rollback(model){
 		if(model.get('hasDirtyAttributes')){

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,3 +1,8 @@
 .active {
   background-color: papayawhip;
 }
+
+.unsaved {
+	color: red;
+	font-weight: bold;
+}

--- a/app/templates/components/reminder-form.hbs
+++ b/app/templates/components/reminder-form.hbs
@@ -18,4 +18,5 @@
 	<button class="revert-input {{if reminder.hasDirtyAttributes "enabled"}}" {{action "rollback" model on="click"}}>Revert</button>
 {{/if}}
 
+
 {{outlet}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -2,11 +2,16 @@
 	{{#if model}}
 		<ul class="reminder-list">
 			{{#each model as |reminder|}}
+			<span class="unsaved">{{if reminder.hasDirtyAttributes "Reminder is not saved!!!"}}</span>
+
 				<li class='reminder'>
+					<div>
+					</div>
 					<h3 class="spec-reminder-title">
 						{{#link-to 'reminders.reminder' reminder class="spec-reminder-item"}}
 							{{reminder.title}}
 						{{/link-to}}
+
 					</h3>
 					<p>{{reminder.date}}</p>
 						{{#link-to 'reminders.edit' reminder class="spec-reminder-edit"}}
@@ -22,6 +27,7 @@
 	<button >
 		{{#link-to 'reminders.new' class="add-btn"}}Add{{/link-to}}
 	</button>
+
 </div>
 
 

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -3,15 +3,11 @@
 		<ul class="reminder-list">
 			{{#each model as |reminder|}}
 			<span class="unsaved">{{if reminder.hasDirtyAttributes "Reminder is not saved!!!"}}</span>
-
 				<li class='reminder'>
-					<div>
-					</div>
 					<h3 class="spec-reminder-title">
 						{{#link-to 'reminders.reminder' reminder class="spec-reminder-item"}}
 							{{reminder.title}}
 						{{/link-to}}
-
 					</h3>
 					<p>{{reminder.date}}</p>
 						{{#link-to 'reminders.edit' reminder class="spec-reminder-edit"}}
@@ -27,7 +23,6 @@
 	<button >
 		{{#link-to 'reminders.new' class="add-btn"}}Add{{/link-to}}
 	</button>
-
 </div>
 
 

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -133,3 +133,16 @@ test('can revert unsaved reminder when editing', function(assert) {
 		assert.equal(Ember.$('.spec-reminder-title').text().trim(), 'hello');
 	});
 });
+
+test('it renders visual cue when reminder is unsaved', function(assert) {
+	visit('/reminders/new');
+
+	fillIn('.input-title', 'hello');
+	fillIn('.input-date', '12/08/2016');
+	fillIn('.input-notes', 'these are notes');
+
+	andThen(function() {
+		assert.equal(find('.unsaved').length, 1);
+		assert.equal(Ember.$('.unsaved').text().trim(), "Reminder is not saved!!!");
+	});
+});


### PR DESCRIPTION
@martensonbj @Tman22 @nfosterky @stevekinney 

## Purpose

User sees visual cue that reminder has not been saved.

When a reminder has changes that have not been saved to the database/server, the user should see some kind of visual indication in the sidebar of the application on that particular note.

## Approach

In the reminders.hbs template, we created a message that only displays based on the condition of the reminder having dirty attributes (not being saved). We added css attributes to make it stand out more, and then added tests to make sure it renders at the correct time.


### Open Questions and Pre-Merge TODOs

- [x] When a reminder has changes that have not been saved to the database/server, the user should see some kind of visual indication in the sidebar of the application on that particular note.
- [x] Add tests for this functionality. 

### Test coverage 

We wrote tests to make sure this message only renders when the reminder is not saved.

### Merge Dependencies and Related Work

This closes #16.

### Follow-up tasks

- [Issue #17 ](https://github.com/turingschool-projects/1608-remember-7/issues/17)

### Screenshots

#### Before
<img width="674" alt="screen shot 2016-12-13 at 1 11 06 pm" src="https://cloud.githubusercontent.com/assets/15853081/21157182/bbdad8e8-c135-11e6-877d-202e8e3df249.png">


#### After

<img width="678" alt="screen shot 2016-12-13 at 1 11 32 pm" src="https://cloud.githubusercontent.com/assets/15853081/21157195/c771092a-c135-11e6-9941-a9a9c709fc6c.png">
