### PR TITLE
Remove Reminder (closes #17

### DIFF
--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -5,10 +5,8 @@ export default Ember.Route.extend({
 	},
 	actions: {
 		handleRemove(model) {
-			console.log(model.id)
-			this.get('store').findRecord('reminder',  model.id).then((record) => {
-			 model.destroyRecord('reminder', model.id);
-		 });
+			let reminderToBeDeleted = this.get('store').peekRecord('reminder',  model.id);
+			 reminderToBeDeleted.destroyRecord('reminder', model.id);
+		 }
 	 }
-	}
 });

--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -2,6 +2,13 @@ import Ember from 'ember';
 export default Ember.Route.extend({
 	model: function() {
 		return this.get('store').findAll('reminder');
+	},
+	actions: {
+		handleRemove(model) {
+			console.log(model.id)
+			this.get('store').findRecord('reminder',  model.id).then((record) => {
+			 model.destroyRecord('reminder', model.id);
+		 });
+	 }
 	}
-
 });

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -2,5 +2,6 @@ import Ember from 'ember';
 export default Ember.Route.extend({
 	model: function(params) {
 		return this.get('store').find('reminder', params.reminder_id);
-	}
+	},
+	
 });

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -13,7 +13,7 @@
 						{{#link-to 'reminders.edit' reminder class="spec-reminder-edit"}}
 							<button class="edit-button">Edit</button>
 							{{/link-to}}
-							<button class="delete-button" {{action 'handleRemove' reminder on="click"}}>{{#link-to 'reminders' }}Delete{{/link-to}}</button>
+							{{#link-to 'reminders' }}<button class="delete-button" {{action 'handleRemove' reminder on="click"}}>Delete</button>{{/link-to}}
 				</li>
 			{{/each}}
 	</ul>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -12,15 +12,19 @@
 					<p>{{reminder.date}}</p>
 						{{#link-to 'reminders.edit' reminder class="spec-reminder-edit"}}
 							<button class="edit-button">Edit</button>
-							{{/link-to}}
-							{{#link-to 'reminders' }}<button class="delete-button" {{action 'handleRemove' reminder on="click"}}>Delete</button>{{/link-to}}
+						{{/link-to}}
+						{{#link-to 'reminders' }}
+							<button class="delete-button" {{action 'handleRemove' reminder on="click"}}>Delete</button>
+						{{/link-to}}
 				</li>
 			{{/each}}
-	</ul>
+		</ul>
 	{{else}}
 		<p class="welcome-default">Welcome! Click 'add' to create a new reminder.</p>
 	{{/if}}
-		{{#link-to 'reminders.new' class="add-btn"}}<button>Add</button>{{/link-to}}
+	{{#link-to 'reminders.new' class="add-btn"}}
+		<button>Add</button>
+	{{/link-to}}
 </div>
 
 

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -12,7 +12,8 @@
 					<p>{{reminder.date}}</p>
 						{{#link-to 'reminders.edit' reminder class="spec-reminder-edit"}}
 							<button class="edit-button">Edit</button>
-						{{/link-to}}
+							{{/link-to}}
+							<button class="delete-button" {{action 'handleRemove' model on="click"}}>{{#link-to 'reminders' }}Delete{{/link-to}}</button>
 				</li>
 			{{/each}}
 	</ul>
@@ -20,9 +21,9 @@
 		<p class="welcome-default">Welcome! Click 'add' to create a new reminder.</p>
 	{{/if}}
 
-	<button >
-		{{#link-to 'reminders.new' class="add-btn"}}Add{{/link-to}}
-	</button>
+
+		{{#link-to 'reminders.new' class="add-btn"}}<button>Add</button>{{/link-to}}
+
 </div>
 
 

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -13,17 +13,14 @@
 						{{#link-to 'reminders.edit' reminder class="spec-reminder-edit"}}
 							<button class="edit-button">Edit</button>
 							{{/link-to}}
-							<button class="delete-button" {{action 'handleRemove' model on="click"}}>{{#link-to 'reminders' }}Delete{{/link-to}}</button>
+							<button class="delete-button" {{action 'handleRemove' reminder on="click"}}>{{#link-to 'reminders' }}Delete{{/link-to}}</button>
 				</li>
 			{{/each}}
 	</ul>
 	{{else}}
 		<p class="welcome-default">Welcome! Click 'add' to create a new reminder.</p>
 	{{/if}}
-
-
 		{{#link-to 'reminders.new' class="add-btn"}}<button>Add</button>{{/link-to}}
-
 </div>
 
 

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -2,7 +2,7 @@
 	<h3 class="spec-reminder-title"> {{model.title}}</h3>
 	<p class="reminder-date"> {{model.date}}</p>
 	<p class="reminder-notes"> {{model.notes}}</p>
-	{{#link-to 'reminders' }}<button class="delete-buttton" {{action 'handleRemove' model on="click"}}>Delete</button>{{/link-to}}
+	{{#link-to 'reminders' }}<button class="individual-delete-button" {{action 'handleRemove' model on="click"}}>Delete</button>{{/link-to}}
 </section>
 
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -2,6 +2,7 @@
 	<h3 class="spec-reminder-title"> {{model.title}}</h3>
 	<p class="reminder-date"> {{model.date}}</p>
 	<p class="reminder-notes"> {{model.notes}}</p>
+	{{#link-to 'reminders' }}<button class="delete-buttton" {{action 'handleRemove' model on="click"}}>Delete</button>{{/link-to}}
 </section>
 
 {{outlet}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -146,3 +146,36 @@ test('it renders visual cue when reminder is unsaved', function(assert) {
 		assert.equal(Ember.$('.unsaved').text().trim(), "Reminder is not saved!!!");
 	});
 });
+
+test('it can delete a reminder with the individual-delete-button and routes back to /reminders', function(assert) {
+  visit('/reminders/new');
+
+	fillIn('.input-title', 'hello');
+	fillIn('.input-date', '12/08/2016');
+	fillIn('.input-notes', 'these are notes');
+
+  click('.add-reminder-submit');
+  click('.delete-button');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders');
+    assert.equal(find('.reminder').length, 0);
+  });
+});
+
+test('it can delete a reminder with the delete-button and routes back to /reminders', function(assert) {
+  visit('/reminders/new');
+
+	fillIn('.input-title', 'hello');
+	fillIn('.input-date', '12/08/2016');
+	fillIn('.input-notes', 'these are notes');
+
+  click('.add-reminder-submit');
+  click('.spec-reminder-title');
+  click('.delete-button');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders');
+    assert.equal(find('.reminder').length, 0);
+  });
+});


### PR DESCRIPTION
## Purpose

- User can remove/delete a reminder. 

- Users should be able to remove a reminder from both the list of reminders or from an individual reminder’s page.

- If a reminder is removed from the individual reminder’s page, then the application should reroute them back to the '/reminders' route.

## Approach

- This PR addresses the problem by allowing the user to click on one of two delete buttons - one which renders in the "reminders list" and one which renders with that individual reminder's notes. 
- Pressing either delete button will trigger the "handleRemove" action, which takes that reminder's id, peeks in the store, and removes it based on its id.

### Learning

We attempted to delete the reminder by finding the record, calling a .then() and calling destroyRecord() on that record. However, this led the browser to throw an error where it would attempt to handle a "notFound" event. We Googled the error and found that the best practice would be to use peekRecord() instead of findRecord(). This made the error go away. 

https://guides.emberjs.com/v2.10.0/models/creating-updating-and-deleting-records/
https://github.com/emberjs/data/issues/3948

#### Blog Posts

### Open Questions and Pre-Merge TODOs

- [x] User can delete reminders with both delete buttons
- [x] Tests cover delete functionality

### Test coverage 

We wrote two additional test to cover the new functionality. Each test covers each individual delete button.
